### PR TITLE
Use int instead of ssize_t for fs_reallocator_skew()

### DIFF
--- a/include/fsalloc.h
+++ b/include/fsalloc.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 typedef void *(*fs_realloc_t)(void *, size_t);
-typedef void (*fs_reallocator_counter_t)(ssize_t count);
+typedef void (*fs_reallocator_counter_t)(int count);
 
 /* Set a custom reallocator. Unlike POSIX realloc(), the argument
  * function must deallocate a memory block if size is zero. */
@@ -59,7 +59,7 @@ fs_reallocator_counter_t fs_get_reallocator_counter(void);
  *   fs_reallocator_skew(1);
  *
  * to balance the books. */
-void fs_reallocator_skew(ssize_t count);
+void fs_reallocator_skew(int count);
 
 #ifdef __cplusplus
 }

--- a/src/fsalloc.c
+++ b/src/fsalloc.c
@@ -29,7 +29,7 @@ fs_realloc_t fs_get_reallocator(void)
     return reallocator;
 }
 
-static void dummy_reallocator_counter(ssize_t count)
+static void dummy_reallocator_counter(int count)
 {
 }
 
@@ -46,7 +46,7 @@ fs_reallocator_counter_t fs_get_reallocator_counter()
     return reallocator_counter;
 }
 
-void fs_reallocator_skew(ssize_t count)
+void fs_reallocator_skew(int count)
 {
     reallocator_counter(count);
 }


### PR DESCRIPTION
ssize_t wasn't readily available on MacOS, and int is a better choice, anyway.