### PR TITLE
Add printf()-like byte array operations

### DIFF
--- a/include/bytearray.h
+++ b/include/bytearray.h
@@ -1,6 +1,7 @@
 #ifndef __FSDYN_BYTEARRAY__
 #define __FSDYN_BYTEARRAY__
 
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
@@ -31,6 +32,10 @@ bool byte_array_copy(byte_array_t *array,
 bool byte_array_copy_string(byte_array_t *array, size_t pos, const char *str);
 bool byte_array_append(byte_array_t *array, const void *data, size_t len);
 bool byte_array_append_string(byte_array_t *array, const char *str);
+bool byte_array_vappendf(byte_array_t *array, const char *fmt, va_list ap)
+    __attribute__((format(printf, 2, 0)));
+bool byte_array_appendf(byte_array_t *array, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
 ssize_t byte_array_append_stream(byte_array_t *array,
                                  byte_array_read_cb read_cb,
                                  void *obj,

--- a/src/bytearray.c
+++ b/src/bytearray.c
@@ -4,7 +4,6 @@
 #include "fsdyn_version.h"
 
 #include <errno.h>
-#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/src/bytearray.c
+++ b/src/bytearray.c
@@ -122,19 +122,14 @@ bool byte_array_vappendf(byte_array_t *array, const char *fmt, va_list ap)
     va_copy(aq, ap);
     ret = vsnprintf(NULL, 0, fmt, aq);
     va_end(aq);
-    if (ret == 0) {
+    if (ret == 0)
         return true;
-    }
-    if (ret < 0) {
+    if (ret < 0)
         return false;
-    }
     len = (size_t)ret;
-    if (!ensure_space(array, len)) {
+    if (!ensure_space(array, len))
         return false;
-    }
-    va_copy(aq, ap);
-    ret = vsnprintf((char *)array->data + array->cursor, len + 1, fmt, aq);
-    va_end(aq);
+    ret = vsnprintf((char *)array->data + array->cursor, len + 1, fmt, ap);
     // assert(ret > 0 && (size_t)ret == len)
     array->cursor += ret;
     return true;

--- a/src/bytearray.c
+++ b/src/bytearray.c
@@ -3,6 +3,7 @@
 #include "fsalloc.h"
 #include "fsdyn_version.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -129,7 +130,7 @@ bool byte_array_vappendf(byte_array_t *array, const char *fmt, va_list ap)
     if (!ensure_space(array, len))
         return false;
     ret = vsnprintf((char *)array->data + array->cursor, len + 1, fmt, ap);
-    // assert(ret > 0 && (size_t)ret == len)
+    assert(ret > 0 && (size_t)ret == len);
     array->cursor += ret;
     return true;
 }

--- a/src/bytearray.c
+++ b/src/bytearray.c
@@ -136,6 +136,7 @@ bool byte_array_vappendf(byte_array_t *array, const char *fmt, va_list ap)
     ret = vsnprintf((char *)array->data + array->cursor, len + 1, fmt, aq);
     va_end(aq);
     // assert(ret > 0 && (size_t)ret == len)
+    array->cursor += ret;
     return true;
 }
 


### PR DESCRIPTION
This PR adds `byte_array_vappendf()` and `byte_array_appendf()`, which append formatted text to a byte array.