### PR TITLE
Add byte_array_to_charstr()

### DIFF
--- a/include/bytearray.h
+++ b/include/bytearray.h
@@ -48,6 +48,11 @@ bool byte_array_resize(byte_array_t *array, size_t n, uint8_t c);
 const void *byte_array_data(byte_array_t *array);
 size_t byte_array_size(byte_array_t *array);
 
+/*
+ * Discards the byte array and returns a copy of its contents.
+ */
+char *byte_array_to_charstr(byte_array_t *array);
+
 #ifdef __cplusplus
 }
 

--- a/src/bytearray.c
+++ b/src/bytearray.c
@@ -194,3 +194,15 @@ size_t byte_array_size(byte_array_t *array)
 {
     return array->cursor;
 }
+
+char *byte_array_to_charstr(byte_array_t *array)
+{
+    char *str = array->data;
+    size_t len = array->cursor;
+
+    if (--array->ref_count) {
+        return charstr_dupsubstr(str, str + len);
+    }
+    fsfree(array);
+    return fsrealloc(str, len + 1);
+}


### PR DESCRIPTION
If the byte array is shared, this decrements the reference count and returns a copy of the contents.  Otherwise, it returns the actual array, trimmed down to its contents, and destroys the metadata structure.  In both cases, the caller has full ownership of the returned string and is responsible for freeing it.

This makes it possible to use a byte array to build a string, then return the result without incurring an additional allocation and copy.